### PR TITLE
Re-init API servers on connection error

### DIFF
--- a/src/radios/radio_browser.py
+++ b/src/radios/radio_browser.py
@@ -38,7 +38,7 @@ class RadioBrowser:
     _host: str | None = None
 
     @backoff.on_exception(
-        backoff.expo, RadioBrowserConnectionError, max_tries=3, logger=None
+        backoff.expo, RadioBrowserConnectionError, max_tries=5, logger=None
     )
     async def _request(
         self,
@@ -105,10 +105,12 @@ class RadioBrowser:
             return await response.json()
 
         except asyncio.TimeoutError as exception:
+            self._host = None
             raise RadioBrowserConnectionTimeoutError(
                 "Timeout occurred while connecting to the Radio Browser API"
             ) from exception
         except (aiohttp.ClientError, socket.gaierror) as exception:
+            self._host = None
             raise RadioBrowserConnectionError(
                 "Error occurred while communicating with the Radio Browser API"
             ) from exception


### PR DESCRIPTION
# Proposed Changes

This PR resets the API host the Radio Browser uses when a connection error occurs.
It causes the API hosts to be re-determined/re-inited on the next try.
