### PR TITLE
feat: Add support to search from country code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/frenck/python-radios"
-version = "0.0.0"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 aiodns = ">=3.0"

--- a/src/radios/radio_browser.py
+++ b/src/radios/radio_browser.py
@@ -77,7 +77,8 @@ class RadioBrowser:
             random.shuffle(result)
             self._host = result[0].host
 
-        url = URL.build(scheme="https", host=self._host, path="/json/").join(URL(uri))
+        url = URL.build(scheme="https", host=self._host,
+                        path="/json/").join(URL(uri))
 
         if self.session is None:
             self.session = aiohttp.ClientSession()
@@ -251,6 +252,7 @@ class RadioBrowser:
         name_exact: bool = False,
         country: str | None = "",
         country_exact: bool = False,
+        country_code: str | None = "",
         state_exact: bool = False,
         language_exact: bool = False,
         tag_exact: bool = False,
@@ -272,6 +274,7 @@ class RadioBrowser:
             name_exact: Search by exact name.
             country: Search by country.
             country_exact: Search by exact country.
+            country_code: Search by country code.
             state_exact: Search by exact state.
             language_exact: Search by exact language.
             tag_exact: Search by exact tag.
@@ -288,25 +291,30 @@ class RadioBrowser:
             uri = f"{uri}/{filter_by.value}"
             if filter_term is not None:
                 uri = f"{uri}/{filter_term}"
+        params = {
+            "hidebroken": hide_broken,
+            "offset": offset,
+            "order": order.value,
+            "reverse": reverse,
+            "limit": limit,
+            "name": name,
+            "name_exact": name_exact,
+            "state_exact": state_exact,
+            "language_exact": language_exact,
+            "tag_exact": tag_exact,
+            "bitrate_min": bitrate_min,
+            "bitrate_max": bitrate_max,
+        }
+        if country_code:
+            params["countrycode"] = country_code
+        elif country:
+            params["country"] = country
+            if country_exact:
+                params["country_exact"] = country_exact
 
         stations_data = await self._request(
             uri,
-            params={
-                "hidebroken": hide_broken,
-                "offset": offset,
-                "order": order.value,
-                "reverse": reverse,
-                "limit": limit,
-                "name": name,
-                "name_exact": name_exact,
-                "country": country,
-                "country_exact": country_exact,
-                "state_exact": state_exact,
-                "language_exact": language_exact,
-                "tag_exact": tag_exact,
-                "bitrate_min": bitrate_min,
-                "bitrate_max": bitrate_max,
-            },
+            params=params
         )
         stations = orjson.loads(stations_data)  # pylint: disable=no-member
         # pylint: disable-next=not-an-iterable


### PR DESCRIPTION
# Proposed Changes

Type: Enhancement / Feature

Description: Added country_code support to search and stations methods.

The search by `country_code` is not supported by the module, although it is supported by radio-browser
This PR adds support for it.
If country_code is passed to `search` method, then `country` and `country_exact` are ignored.

I verified it via local editable install and ipython


